### PR TITLE
cherry-pick: Admin Flow fixed

### DIFF
--- a/src/components/adminConnectionsTable.jsx
+++ b/src/components/adminConnectionsTable.jsx
@@ -1,13 +1,11 @@
 import {
-  Bullseye,
   EmptyState,
   EmptyStateVariant,
   List,
   ListItem,
   Popover,
   Title,
-  ActionGroup,
-  Button,
+  EmptyStateBody,
 } from '@patternfly/react-core'
 import { ExclamationTriangleIcon } from '@patternfly/react-icons'
 import {
@@ -19,34 +17,14 @@ import {
   OuterScrollContainer,
   InnerScrollContainer,
   sortable,
-  SortByDirection,
+  SortByDirection
 } from '@patternfly/react-table'
 import _ from 'lodash'
-import React, { useState } from 'react'
+import React from 'react'
 import {
-  cockroachdbProviderName,
-  cockroachdbProviderType,
-  crunchyProviderName,
-  crunchyProviderType,
-  mongoProviderName,
-  mongoProviderType,
   DBaaSInventoryCRName,
-  DBaaSOperatorName,
 } from '../const.ts'
-import { fetchDbaasCSV } from '../utils'
 import './_dbaas-import-view.css'
-
-const TableEmptyState = () => {
-  return (
-    <Bullseye>
-      <EmptyState variant={EmptyStateVariant.small}>
-        <Title headingLevel="h2" size="lg">
-          No database instances
-        </Title>
-      </EmptyState>
-    </Bullseye>
-  )
-}
 
 class AdminConnectionsTable extends React.Component {
   constructor(props) {
@@ -65,10 +43,15 @@ class AdminConnectionsTable extends React.Component {
       ],
       rows: [],
       dBaaSOperatorNameWithVersion: this.props.dBaaSOperatorNameWithVersion,
+      noInstances: this.props.noInstances,
       sortBy: {},
     }
     this.getRows = this.getRows.bind(this)
     this.onSort = this.onSort.bind(this)
+  }
+
+  componentDidMount() {
+    this.getRows(this.props.inventoryInstances)
   }
 
   componentDidUpdate(prevProps) {
@@ -84,10 +67,6 @@ class AdminConnectionsTable extends React.Component {
         this.getRows(this.props.inventoryInstances)
       }
     }
-  }
-
-  componentDidMount() {
-    this.getRows(this.props.inventoryInstances)
   }
 
   onSort = (_event, index, direction) => {
@@ -179,15 +158,27 @@ class AdminConnectionsTable extends React.Component {
         })
       })
     } else {
+      // Empty State for the table
       rowList.push({
         heightAuto: true,
         cells: [
           {
             props: { colSpan: 8 },
-            title: <TableEmptyState />,
-          },
-        ],
-      })
+            title: (
+              <EmptyState variant={EmptyStateVariant.small}>
+                <Title headingLevel="h2" size="lg">
+                  {this.state.noInstances ? 'No database provider account imported' : 'No database instances'}
+                </Title>
+                <EmptyStateBody>
+                  {this.state.noInstances
+                    ? 'Please import your database provider account to view available database instances.'
+                    : ''}
+                </EmptyStateBody>
+              </EmptyState>
+            )
+          }
+        ]
+      });
     }
     this.setState({ rows: rowList })
   }

--- a/src/components/adminDashboard.jsx
+++ b/src/components/adminDashboard.jsx
@@ -77,7 +77,11 @@ const AdminDashboard = () => {
     <DropdownItem key="link" href={`/k8s/ns/${currentNS}/rhoda-admin-dashboard/import-provider-account`}>
       Import Database Provider Account
     </DropdownItem>,
-    <DropdownItem key="dbinstancelink" href={`/k8s/ns/${currentNS}/rhoda-create-database-instance`}>
+    <DropdownItem
+      key="dbinstancelink"
+      href={`/k8s/ns/${currentNS}/rhoda-create-database-instance`}
+      isDisabled={noInstances}
+    >
       Create Database Instance
     </DropdownItem>,
   ]
@@ -258,41 +262,25 @@ const AdminDashboard = () => {
     window.location.pathname = `/k8s/ns/${currentNS}/clusterserviceversions/${dBaaSOperatorNameWithVersion}/${DBaaSInventoryCRName}/~new`
   }
 
-  const displayEmptyState = () => {
-    if (fetchInstancesFailed) {
-      return (
-        <EmptyState>
-          <EmptyStateIcon variant="container" component={InfoCircleIcon} className="warning-icon" />
-          <Title headingLevel="h2" size="md">
-            Database instances retrieval failed
-          </Title>
-          <EmptyStateBody>Database instances could not be retrieved. Please try again.</EmptyStateBody>
-          <Alert variant="danger" isInline title="An error occured" className="co-alert co-break-word extra-top-margin">
-            <div>{statusMsg}</div>
-          </Alert>
-          <Button variant="primary" onClick={handleTryAgain}>
-            Try Again
-          </Button>
-          <EmptyStateSecondaryActions>
-            <Button variant="link" onClick={handleCancel}>
-              Close
-            </Button>
-          </EmptyStateSecondaryActions>
-        </EmptyState>
-      )
-    }
+  const displayInstancesFailed = () => {
     return (
       <EmptyState>
         <EmptyStateIcon variant="container" component={InfoCircleIcon} className="warning-icon" />
         <Title headingLevel="h2" size="md">
-          No Database Instances
+          Database instances retrieval failed
         </Title>
-        <EmptyStateBody>
-          Database instances are shown here once you've imported your first Provider Account.
-        </EmptyStateBody>
-        <Button variant="primary" onClick={goToCreateProviderPage}>
-          Import Provider Account
+        <EmptyStateBody>Database instances could not be retrieved. Please try again.</EmptyStateBody>
+        <Alert variant="danger" isInline title="An error occured" className="co-alert co-break-word extra-top-margin">
+          <div>{statusMsg}</div>
+        </Alert>
+        <Button variant="primary" onClick={handleTryAgain}>
+          Try Again
         </Button>
+        <EmptyStateSecondaryActions>
+          <Button variant="link" onClick={handleCancel}>
+            Close
+          </Button>
+        </EmptyStateSecondaryActions>
       </EmptyState>
     )
   }
@@ -325,8 +313,8 @@ const AdminDashboard = () => {
           </EmptyState>
         ) : (
           <>
-            {fetchInstancesFailed || noInstances ? (
-              displayEmptyState()
+            {fetchInstancesFailed ? (
+              displayInstancesFailed()
             ) : (
               <>
                 <Split>
@@ -361,6 +349,7 @@ const AdminDashboard = () => {
                     filteredInstances={filteredInstances}
                     dBaaSOperatorNameWithVersion={dBaaSOperatorNameWithVersion}
                     inventoryInstances={inventoryInstances}
+                    noInstances={noInstances}
                   />
                 </FormSection>
               </>


### PR DESCRIPTION
-Using the same page for the Empty State if there are no providers.
-Disabled the "Create database instance" option (as no Database Provider has been imported yet)
-Added EmptyStateBody to display the text.
-Removed unused imports/vars

Signed-off-by: Olga Lavtar <olavtar@redhat.com>