### PR TITLE
DBAAS-599-Tooltip-Title: Cherry-picking for 0.1.5

### DIFF
--- a/src/components/adminConnectionsTable.jsx
+++ b/src/components/adminConnectionsTable.jsx
@@ -98,7 +98,7 @@ class AdminConnectionsTable extends React.Component {
               <div>
                 <Popover
                   aria-label="Basic popover"
-                  headerContent={<div>Issue</div>}
+                  headerContent={inventoryInstance.alert !== 'alert' ? <div>Connection issue</div> : <div>Issue</div>}
                   bodyContent={
                     inventoryInstance.alert !== 'alert' ? (
                       <div>


### PR DESCRIPTION
Cherry-picking for 0.1.5
Fixed the title to display "Connection Issue" vs "Issue" if there is an "AuthenticationError".

Signed-off-by: Olga Lavtar <olavtar@redhat.com>