### PR TITLE
[DBAAS-608] inventories should only reference secrets in the same ns

### DIFF
--- a/src/components/providerAccountForm.jsx
+++ b/src/components/providerAccountForm.jsx
@@ -250,7 +250,6 @@ class ProviderAccountForm extends React.Component {
           },
           credentialsRef: {
             name: secretName,
-            namespace: this.state.currentNS,
           },
         },
       }),


### PR DESCRIPTION
https://issues.redhat.com/browse/DBAAS-608

related to https://github.com/RHEcosystemAppEng/dbaas-operator/pull/186

Signed-off-by: Tommy Hughes <tohughes@redhat.com>