### PR TITLE
[DBAAS-306] change Database Access inventory view based on namespace

### DIFF
--- a/src/components/adminDashboard.jsx
+++ b/src/components/adminDashboard.jsx
@@ -267,7 +267,9 @@ const AdminDashboard = () => {
             }
           }
 
-          inventoriesAll.push(obj)
+          if (allNamespaces || obj.namespace === currentNS) {
+            inventoriesAll.push(obj)
+          }
         })
         setInventories(inventoriesAll)
       }


### PR DESCRIPTION
With this change we more closely mimic standard OCP console behavior.

When a namespace is selected from the drop down, users will only see inventories in that chosen namespace -
![Screen Shot 2023-01-25 at 12 15 11 PM](https://user-images.githubusercontent.com/11095048/214648621-41704cd2-a298-4d57-a8c8-156c0eb843c1.png)
![Screen Shot 2023-01-25 at 12 15 01 PM](https://user-images.githubusercontent.com/11095048/214649635-e2c8cd5d-f355-4102-b78c-4b234b194afa.png)
![Screen Shot 2023-01-25 at 12 22 39 PM](https://user-images.githubusercontent.com/11095048/214649794-0cf560be-0bba-4b75-a8f2-b300d49422ad.png)

When "All Projects" is selected, users will see all inventories in the cluster that they have access to view -
![Screen Shot 2023-01-25 at 12 15 15 PM](https://user-images.githubusercontent.com/11095048/214649082-071d2527-2d53-4323-83c5-74619d275977.png)
![Screen Shot 2023-01-25 at 12 21 02 PM](https://user-images.githubusercontent.com/11095048/214649397-9f8704a9-7aa3-42f1-bac6-7dd8210e0957.png)

Signed-off-by: Tommy Hughes <tohughes@redhat.com>
