### PR TITLE
DBAAS-1208: Prevent 'instance name' field from being cleared

### DIFF
--- a/src/components/providerClusterProvisionPage.jsx
+++ b/src/components/providerClusterProvisionPage.jsx
@@ -1007,17 +1007,9 @@ const ProviderClusterProvisionPage = () => {
     providerChosenOptionsMap.clear()
     setProviderChosenOptionsMap(new Map(providerChosenOptionsMap.set('plan', plan)))
     setProviderChosenOptionsMap(new Map(providerChosenOptionsMap.set('cloudProvider', cloudProvider)))
+    setProviderChosenOptionsMap(new Map(providerChosenOptionsMap.set('name', clusterName)))
 
-    const sortedFields = [
-      'regions',
-      'spendLimit',
-      'nodes',
-      'databaseType',
-      'machineType',
-      'storageGib',
-      'teamProject',
-      'name',
-    ]
+    const sortedFields = ['regions', 'spendLimit', 'nodes', 'databaseType', 'machineType', 'storageGib', 'teamProject']
 
     setDefaultsForDependentFields(sortedFields)
   }


### PR DESCRIPTION
Prevent 'instance name' field from being cleared when dropdown selection changes.
Jira: https://issues.redhat.com/browse/DBAAS-1208

Signed-off-by: Olga Lavtar <olavtar@redhat.com>